### PR TITLE
client id management

### DIFF
--- a/server/state_machine.py
+++ b/server/state_machine.py
@@ -15,6 +15,7 @@ import random
 import game_type
 import threading
 import logging
+import uuid
 
 class StateMachine:
 
@@ -58,8 +59,7 @@ class StateMachine:
 
                     logging.debug("valid game type received: {}".format(self.msg_recvd.payload))
                     self.gametype = self.msg_recvd.payload
-
-                    self.client_id = random.randint(1,256)
+                    self.client_id = uuid.uuid4().time_low
                     msg_to_send = message_creation.create_client_id_assign_message(self.version, self.client_id)
                     self.printMessageToSend("CLIENTIDASSIGN", msg_to_send)
                     self.clientsocket.send(msg_to_send)

--- a/server/state_machine.py
+++ b/server/state_machine.py
@@ -59,6 +59,8 @@ class StateMachine:
 
                     logging.debug("valid game type received: {}".format(self.msg_recvd.payload))
                     self.gametype = self.msg_recvd.payload
+                    #generates a random unique id that is 128 bits long - time_low gets us the first 32-bits of it - not sure if this will cause collision issues since we aren't using all 128 bits (maybe we should consider making client_id 128 bits)
+                    #no need for central repository as module uuid generates ids in accordance with RFC4122
                     self.client_id = uuid.uuid4().time_low
                     msg_to_send = message_creation.create_client_id_assign_message(self.version, self.client_id)
                     self.printMessageToSend("CLIENTIDASSIGN", msg_to_send)


### PR DESCRIPTION
shockingly simple -- made use of python's uuid module which generates a 128-bit random id.  The code uses the time_low attribute to get the first 32 bits of it (not sure if this will cause collisions since we aren't using all 128 bits).  No need for central repository as uuid generates unique id's in accordance with RFC 4122
